### PR TITLE
Improve get_pairwise_membership efficiency

### DIFF
--- a/R/compare_bioregionalizations.R
+++ b/R/compare_bioregionalizations.R
@@ -354,7 +354,7 @@ get_pairwise_membership <- function(input_clusters) {
   # Compute pairwise membership
   for (col in seq_len(n_bioregionalizations)) {
     # Compare memberships directly for each pair of items
-    pw_membership[, col] <- as.vector(dist(as.integer(input_clusters[, col])) == 0)
+    pw_membership[, col] <- as.vector(dist(as.integer(as.factor(input_clusters[, col]))) == 0)
   }
   
   # Set row names based on the pairwise comparisons (optional)

--- a/R/compare_bioregionalizations.R
+++ b/R/compare_bioregionalizations.R
@@ -351,21 +351,16 @@ get_pairwise_membership <- function(input_clusters) {
   pw_membership <- matrix(FALSE, nrow = choose(n_items, 2),
                           ncol = n_bioregionalizations)
   
-  # Get all unique pairwise comparisons indices
-  pairwise_comps <- t(utils::combn(seq_len(n_items), 2))
-  
   # Compute pairwise membership
   for (col in seq_len(n_bioregionalizations)) {
-    # Extract cluster memberships for this bioregionalization
-    cluster_col <- input_clusters[, col]
-    
     # Compare memberships directly for each pair of items
-    pw_membership[, col] <- cluster_col[pairwise_comps[, 1]] == 
-      cluster_col[pairwise_comps[, 2]]
+    pw_membership[, col] <- as.vector(dist(as.integer(input_clusters[, col])) == 0)
   }
   
   # Set row names based on the pairwise comparisons (optional)
-  rownames(pw_membership) <- apply(pairwise_comps, 1, paste, collapse = "_")
+  cl1 <- rep(seq_len(n_items - 1), times = (n_items - 1):1)
+  cl2 <- sequence((n_items - 1):1) + cl1
+  rownames(pw_membership) <- paste(cl1, cl2, sep = "_")
   colnames(pw_membership) <- colnames(input_clusters)
   
   return(pw_membership)


### PR DESCRIPTION
Hi, 

I'm interested in using various functions from your package, but I've found the `compare_bioregionalizations` function to be prohibitively slow for my use case due to the internal `get_pairwise_membership` function. Computing pairwise membership using `dist` turns out to be much faster and memory efficient than identifying pairs using `combn`. This is a very small pull request with a minor code change, but in my case I'm working with a fairly large clustering / bioregionalization dataset and it speeds up execution of the compare_bioregionalizations function by an order of magnitude, and reduces memory usage by about half:

<img width="1800" height="1500" alt="get_pairwise_membership_benchmark" src="https://github.com/user-attachments/assets/49869960-72fa-4e57-9960-57d3a2c1bc81" />

The outputs are identical, of course, and all tests passed when I ran them locally.

Best,
Maurice Goodman